### PR TITLE
Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,21 @@
-FROM rocker/r-ver:4.0.2
+FROM rocker/shiny-verse:4.0.2
 RUN apt-get update && apt-get install -y  gdal-bin git-core libcurl4-openssl-dev libgdal-dev libgeos-dev libgeos++-dev libgit2-dev libpng-dev libssh2-1-dev libssl-dev libudunits2-dev libxml2-dev make pandoc pandoc-citeproc zlib1g-dev && rm -rf /var/lib/apt/lists/*
 RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site
 RUN R -e 'install.packages("remotes")'
 RUN R -e 'remotes::install_github("r-lib/remotes", ref = "97bbf81")'
-RUN Rscript -e 'remotes::install_version("magrittr",upgrade="never", version = "1.5")'
-RUN Rscript -e 'remotes::install_version("glue",upgrade="never", version = "1.4.1")'
-RUN Rscript -e 'remotes::install_version("stringr",upgrade="never", version = "1.4.0")'
-RUN Rscript -e 'remotes::install_version("processx",upgrade="never", version = "3.4.3")'
-RUN Rscript -e 'remotes::install_version("pkgload",upgrade="never", version = "1.1.0")'
-RUN Rscript -e 'remotes::install_version("testthat",upgrade="never", version = "2.3.2")'
-RUN Rscript -e 'remotes::install_version("leaflet",upgrade="never", version = "2.0.3")'
-RUN Rscript -e 'remotes::install_version("htmltools",upgrade="never", version = "0.5.0")'
-RUN Rscript -e 'remotes::install_version("tidyr",upgrade="never", version = "1.1.1")'
-RUN Rscript -e 'remotes::install_version("dplyr",upgrade="never", version = "1.0.1")'
-RUN Rscript -e 'remotes::install_version("knitr",upgrade="never", version = "1.29")'
-RUN Rscript -e 'remotes::install_version("attempt",upgrade="never", version = "0.3.1")'
-RUN Rscript -e 'remotes::install_version("shiny",upgrade="never", version = "1.5.0")'
-RUN Rscript -e 'remotes::install_version("usethis",upgrade="never", version = "1.6.1")'
-RUN Rscript -e 'remotes::install_version("config",upgrade="never", version = "0.3")'
-RUN Rscript -e 'remotes::install_version("rmarkdown",upgrade="never", version = "2.3")'
-RUN Rscript -e 'remotes::install_version("shinycssloaders",upgrade="never", version = "1.0.0")'
-RUN Rscript -e 'remotes::install_version("shinyWidgets",upgrade="never", version = "0.5.3")'
-RUN Rscript -e 'remotes::install_version("rcartocolor",upgrade="never", version = "2.0.0")'
-RUN Rscript -e 'remotes::install_version("tmap",upgrade="never", version = "3.1")'
-RUN Rscript -e 'remotes::install_version("echarts4r",upgrade="never", version = "0.3.2")'
-RUN Rscript -e 'remotes::install_version("DT",upgrade="never", version = "0.15")'
-RUN Rscript -e 'remotes::install_version("golem",upgrade="never", version = "0.2.1")'
+RUN install2.r -r https://packagemanager.rstudio.com/all/344 -e  echarts4r \
+                DT \
+                tmap \
+                golem \
+                processx \
+                pkgload \
+                leaflet \
+                htmltools \
+                attempt \
+                config \
+                shinycssloaders \
+                shinyWidgets \
+                rcartocolor
 RUN Rscript -e 'remotes::install_github("tidyverse/ggplot2@59998893ef7d1f5c36b3ecfff93bbe6091d589ba")'
 RUN Rscript -e 'remotes::install_github("JohnCoene/typed@31e6d3be6a82486c891fbb615b83811cf698aa5a")'
 RUN Rscript -e 'remotes::install_github("hadley/emo@3f03b11491ce3d6fc5601e210927eff73bf8e350")'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.0"
+services:
+    xbikes:
+        build: "."
+        ports: 
+            - "3388:80"


### PR DESCRIPTION
this PR adds a small docker compose and changes the dockerfile so that it is more compact and will run faster by:
- install2r script instead of multipe RUN RScripts : https://github.com/eddelbuettel/littler 
- use Rstudio package manager (https://packagemanager.rstudio.com/client/#/repos/1/overview) to get faster build times (can get some packages as binaries instead of compiling everything from source)
-  by using https://packagemanager.rstudio.com/all/344 instead of https://packagemanager.rstudio.com/all/latest , the packages are fixed as they are available for the r version of the docker image as of 2020-10-13. 